### PR TITLE
Add Bean.disconnect() method

### DIFF
--- a/hardware/bean/cores/bean/Bean.cpp
+++ b/hardware/bean/cores/bean/Bean.cpp
@@ -642,3 +642,8 @@ uint16_t BeanClass::getBatteryVoltage(void)
   {
     Serial.enableWakeOnConnect( enable );
   }
+
+void BeanClass::disconnect(void)
+{
+  Serial.BTDisconnect();
+}

--- a/hardware/bean/cores/bean/Bean.h
+++ b/hardware/bean/cores/bean/Bean.h
@@ -49,6 +49,8 @@ public:
   void setBeaconEnable( bool beaconEnable );
   void enableWakeOnConnect( bool enable );
 
+  void disconnect (void);
+
   BeanClass(){}
 
 private:

--- a/hardware/bean/cores/bean/BeanSerialTransport.cpp
+++ b/hardware/bean/cores/bean/BeanSerialTransport.cpp
@@ -502,7 +502,7 @@ void BeanSerialTransport::BTSetBeaconParams(uint16_t uuid, uint16_t majorid, uin
 
 void BeanSerialTransport::BTDisconnect(void)
 {
-  write_message(MSG_ID_BT_DISCONNECT, null, 0);
+  write_message(MSG_ID_BT_DISCONNECT, NULL, 0);
 }
 
 ////////

--- a/hardware/bean/cores/bean/BeanSerialTransport.cpp
+++ b/hardware/bean/cores/bean/BeanSerialTransport.cpp
@@ -500,6 +500,11 @@ void BeanSerialTransport::BTSetBeaconParams(uint16_t uuid, uint16_t majorid, uin
 
 }
 
+void BeanSerialTransport::BTDisconnect(void)
+{
+  write_message(MSG_ID_BT_DISCONNECT, null, 0);
+}
+
 ////////
 // LED
 ////////

--- a/hardware/bean/cores/bean/BeanSerialTransport.h
+++ b/hardware/bean/cores/bean/BeanSerialTransport.h
@@ -47,6 +47,7 @@ protected:
   int  BTGetStates(BT_STATES_T * btStates );
   void BTSetBeaconParams(uint16_t uuid, uint16_t majorid, uint16_t minorid );
   void BTBeaconModeEnable( bool beaconEnable );
+  void BTDisconnect(void);
 
 
   //LED Control


### PR DESCRIPTION
Allows us to use `Bean.disconnect()` from Arduino. This tells the Bean to drop the current connection with a BLE Central device.