### PR TITLE
Fix pin change interrupts

### DIFF
--- a/examples/LightBlueBean/01.Basics/ChangeInterrupts/ChangeInterrupts.ino
+++ b/examples/LightBlueBean/01.Basics/ChangeInterrupts/ChangeInterrupts.ino
@@ -31,13 +31,34 @@ void twoChangeDetected( void )
   blue += 16;
 }
 
+void threeChangeDetected( void )
+{
+  red = 0;
+}
+
+void fourChangeDetected( void )
+{
+  green = 0;
+}
+
+void fiveChangeDetected( void )
+{
+  blue = 0;
+}
+
 void setup() {
   pinMode(0, INPUT);
   pinMode(1, INPUT);
   pinMode(2, INPUT);
+  pinMode(3, INPUT);
+  pinMode(4, INPUT);
+  pinMode(5, INPUT);
   PCintPort::attachInterrupt(0, zeroChangeDetected, CHANGE);
   PCintPort::attachInterrupt(1, oneChangeDetected, CHANGE);
   PCintPort::attachInterrupt(2, twoChangeDetected, CHANGE);
+  PCintPort::attachInterrupt(3, threeChangeDetected, CHANGE);
+  PCintPort::attachInterrupt(4, fourChangeDetected, CHANGE);
+  PCintPort::attachInterrupt(5, fiveChangeDetected, CHANGE);
   Bean.setLed(0xFF, 0xFF, 0xFF);  // Flash to show the sketch is running
   Bean.sleep(250);
 }

--- a/examples/LightBlueBean/01.Basics/ChangeInterrupts/ChangeInterrupts.ino
+++ b/examples/LightBlueBean/01.Basics/ChangeInterrupts/ChangeInterrupts.ino
@@ -1,0 +1,48 @@
+/* 
+  This sketch uses the Bean library to trigger interrupts when changes are detected on pins 0, 1, and 2. 
+  
+  Notes:
+    - This is not a low-power sketch 
+    - A Bean with a low battery might show a faint blue and green LED color
+  
+  This example code is in the public domain.
+*/
+
+volatile uint8_t red = 0;
+volatile uint8_t green = 0;
+volatile uint8_t blue = 0;
+
+// Interrupts are meant to be fast, avoid doing Bean.* operations directly within ISRs
+//   Set a flag and perform the desired operation within the superloop
+void zeroChangeDetected( void )
+{
+  red += 16;
+}
+
+void oneChangeDetected( void )
+{
+  green += 16;
+}
+
+void twoChangeDetected( void )
+{
+  blue += 16;
+}
+
+void setup() {
+  pinMode(0, INPUT);
+  pinMode(1, INPUT);
+  pinMode(2, INPUT);
+  Bean.attachChangeInterrupt(0, zeroChangeDetected);
+  Bean.attachChangeInterrupt(1, oneChangeDetected);
+  Bean.attachChangeInterrupt(2, twoChangeDetected);
+  Bean.setLed(0xFF, 0xFF, 0xFF);  // Flash to show the sketch is running
+  Bean.sleep(250);
+}
+
+void loop() {
+  // Set the Bean's LED based upon RGBs changed by interrupts
+  //   Eventually, overflow will turn the colors off
+  Bean.setLed(red, green, blue);
+  Bean.sleep(100);
+}

--- a/examples/LightBlueBean/01.Basics/ChangeInterrupts/ChangeInterrupts.ino
+++ b/examples/LightBlueBean/01.Basics/ChangeInterrupts/ChangeInterrupts.ino
@@ -1,3 +1,5 @@
+#include <PinChangeInt.h>
+
 /* 
   This sketch uses the Bean library to trigger interrupts when changes are detected on pins 0, 1, and 2. 
   
@@ -33,9 +35,9 @@ void setup() {
   pinMode(0, INPUT);
   pinMode(1, INPUT);
   pinMode(2, INPUT);
-  Bean.attachChangeInterrupt(0, zeroChangeDetected);
-  Bean.attachChangeInterrupt(1, oneChangeDetected);
-  Bean.attachChangeInterrupt(2, twoChangeDetected);
+  PCintPort::attachInterrupt(0, zeroChangeDetected, CHANGE);
+  PCintPort::attachInterrupt(1, oneChangeDetected, CHANGE);
+  PCintPort::attachInterrupt(2, twoChangeDetected, CHANGE);
   Bean.setLed(0xFF, 0xFF, 0xFF);  // Flash to show the sketch is running
   Bean.sleep(250);
 }

--- a/hardware/bean/avr/cores/bean/Bean.cpp
+++ b/hardware/bean/avr/cores/bean/Bean.cpp
@@ -27,43 +27,6 @@ do { \
 #define MAX_SCRATCH_SIZE (20)
 #define NUM_BEAN_PINS 7
 
-static volatile voidFuncPtr intFuncs[6];
-static volatile uint8_t     pinStates[6];
-
-// Pin change interrupt vectors
-
-// D0
-ISR(PCINT2_vect)
-{
-  pinStates[0] = digitalRead(0);
-  if(intFuncs[0])
-  {
-    intFuncs[0]();
-  }
-}
-
-// Analog 0, Analog 1
-ISR(PCINT1_vect)
-{
-  // Nobody loves me
-}
-
-// D1-D5
-ISR(PCINT0_vect)
-{
-  for (uint8_t i = 1; i < 6; i++)
-  {
-    if (pinStates[i] != digitalRead(i))
-    {
-      pinStates[i] = digitalRead(i);
-      if (intFuncs[i] != NULL)
-      {
-        intFuncs[i]();
-      }
-    }
-  }
-}
-
   BeanClass Bean;
 
   static void wakeUp(void){
@@ -282,79 +245,6 @@ ISR(PCINT0_vect)
     }
 }
 
-
-  void BeanClass::attachChangeInterrupt(uint8_t pin, void(*userFunc)(void) )
-  {
-      PCIFR = 0x07;  // Clear any pending interrupts
-      pinStates[pin] = digitalRead(pin);
-      intFuncs[pin] = userFunc;
-      switch( pin )
-      {
-        case 0:
-          PCICR |= _BV(PCIE2);
-          PCMSK2 |= _BV(PCINT22);
-          break;
-        case 1:
-          PCICR |= _BV(PCIE0);
-          PCMSK0 |= _BV(PCINT1);
-          break;
-        case 2:
-          PCICR |= _BV(PCIE0);
-          PCMSK0 |= _BV(PCINT2);
-          break;
-        case 3:
-          PCICR |= _BV(PCIE0);
-          PCMSK0 |= _BV(PCINT3);
-          break;
-        case 4:
-          PCICR |= _BV(PCIE0);
-          PCMSK0 |= _BV(PCINT4);
-          break;
-        case 5:
-          PCICR |= _BV(PCIE0);
-          PCMSK0 |= _BV(PCINT5);
-          break;
-
-        default:
-          break;
-      }
-
-  }
-
-  void BeanClass::detachChangeInterrupt(uint8_t pin)
-  {
-      intFuncs[pin] = NULL;
-      switch( pin )
-      {
-        case 0:
-          PCICR &= ~_BV(PCIE2);
-          PCMSK2 &= ~_BV(PCINT22);
-          break;
-        case 1:
-          PCICR &= ~_BV(PCIE0);
-          PCMSK0 &= ~_BV(PCINT1);
-          break;
-        case 2:
-          PCICR &= ~_BV(PCIE0);
-          PCMSK0 &= ~_BV(PCINT2);
-          break;
-        case 3:
-          PCICR &= ~_BV(PCIE0);
-          PCMSK0 &= ~_BV(PCINT3);
-          break;
-        case 4:
-          PCICR &= ~_BV(PCIE0);
-          PCMSK0 &= ~_BV(PCINT4);
-          break;
-        case 5:
-          PCICR &= ~_BV(PCIE0);
-          PCMSK0 &= ~_BV(PCINT5);
-          break;
-
-        default:
-          break;
-      }
-  }
 
 void BeanClass::setAdvertisingInterval( uint16_t interval_ms )
 {

--- a/hardware/bean/avr/cores/bean/Bean.h
+++ b/hardware/bean/avr/cores/bean/Bean.h
@@ -47,8 +47,6 @@ public:
   void sleep(uint32_t duration_ms);
   void keepAwake(bool enable);
 
-  void attachChangeInterrupt(uint8_t pin, void(*userFunc)(void) );
-  void detachChangeInterrupt(uint8_t pin);
   void setAdvertisingInterval( uint16_t interval_ms );
   void enableAdvertising(bool enable, uint32_t timer);
   void enableAdvertising(bool enable);
@@ -65,7 +63,6 @@ public:
 
 private:
   bool attemptSleep( uint32_t duration_ms);
-  int16_t convertAcceleration(uint8_t high_byte, uint8_t low_byte);
 
 
 };

--- a/hardware/bean/avr/variants/bean+/pins_arduino.h
+++ b/hardware/bean/avr/variants/bean+/pins_arduino.h
@@ -54,8 +54,8 @@ static const uint8_t CC_INTERRUPT_PIN = 16;
 // TODO - I don't know what this stuff is
 #define digitalPinToPCICR(p)    (((p) >= 0 && (p) <= 21) ? (&PCICR) : ((uint8_t *)0))
 #define digitalPinToPCICRbit(p) (((p) <= 7) ? 2 : (((p) <= 13) ? 0 : 1))
-#define digitalPinToPCMSK(p)    (((p) <= 7) ? (&PCMSK2) : (((p) <= 13) ? (&PCMSK0) : (((p) <= 21) ? (&PCMSK1) : ((uint8_t *)0))))
-#define digitalPinToPCMSKbit(p) (((p) <= 7) ? (p) : (((p) <= 13) ? ((p) - 8) : ((p) - 14)))
+#define digitalPinToPCMSK(p)    (((p) <= 3) ? (&PCMSK2) : (&PCMSK0))
+#define digitalPinToPCMSKbit(p) (((p) >= 4) ? (p - 4) : (((p) <= 2) ? (2*p+2) : (7)))
 
 #ifdef ARDUINO_MAIN
 


### PR DESCRIPTION
With a little behind the scenes code it also allows the user to have an independent interrupt for every digital pin, even though the micro controller only supports 3 interrupts.