### PR TITLE
git: Use https: url to prevent issues with cloning this repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hardware/bean/avr/cores/bean/applicationMessageHeaders"]
 	path = hardware/bean/avr/cores/bean/applicationMessageHeaders
-	url = git@bitbucket.org:punchthroughdesign/bean-application-message-definitions.git
+	url = https://bitbucket.org/punchthroughdesign/bean-application-message-definitions.git


### PR DESCRIPTION
Bitbucket requires you to have an associated SSH key to clone using `git:` urls. This change makes it so that you can clone this public repo from Bitbucket without authenticating.